### PR TITLE
Add ata driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ C_SOURCES = $(wildcard \
  drivers/*/*.cpp \
  drivers/*/*/*.cpp \
  drivers/*/*/*.c \
+ drivers/*/*.c \
  cpu/*.cpp \
  libc/*.cpp \
  kernel/*.cpp \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ C_SOURCES = $(wildcard \
  arch/x86/*.cpp \
  drivers/*.cpp \
  drivers/*/*.cpp \
+ drivers/*/*/*.cpp \
+ drivers/*/*/*.c \
  cpu/*.cpp \
  libc/*.cpp \
  kernel/*.cpp \

--- a/drivers/blocks/ata/ata_pio.c
+++ b/drivers/blocks/ata/ata_pio.c
@@ -3,6 +3,7 @@
 #include <arch/x86/io/ports.h>
 #include <arch/cpu_control.h>
 #include <arch/interrupt_controller.h>
+#include <drivers/blocks/block_device.h>
 #include <cpu/int.h>
 #include <libc/string.h>
 #include <libc/log.h>
@@ -75,7 +76,10 @@ flags
 * ATA Functions
 */
 ata_device_t* ata_get_device(uint8_t index);
+void ata_read_block(block_device_t* device, uint64_t lba, void* buffer, uint32_t size);
+void ata_write_block(block_device_t* device, uint64_t lba, void* buffer, uint32_t size);
 void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
+void ata_write_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
 static void ata_select_drive(ata_device_t* device);
 static uint8_t ata_read_status(ata_device_t* device);
 static void ata_identify(ata_device_t* device);
@@ -86,6 +90,14 @@ void ata_secondary_irq_handler(registers_t regs);
 static ata_device_t* devices;
 static uint8_t ata_primary_irq;
 static uint8_t ata_secondary_irq;
+
+void ata_read_block(block_device_t* device, uint64_t lba, void* buffer, uint32_t size){
+    ata_read_lba28((ata_device_t*)device->data, lba, buffer, size);
+}
+
+void ata_write_block(block_device_t* device, uint64_t lba, void* buffer, uint32_t size){
+    ata_write_lba28((ata_device_t*)device->data, lba, buffer, size);
+}
 
 static void ata_init_device(ata_device_t* device, uint16_t base, uint16_t control, uint8_t slave){
     device->base = base;
@@ -106,10 +118,19 @@ void ata_init(){
     ata_init_device(&devices[1], ATA_PRIMARY_BASE, ATA_PRIMARY_CONTROL, ATA_SLAVE_DRIVE);
     ata_init_device(&devices[2], ATA_SECONDARY_BASE, ATA_SECONDARY_CONTROL, ATA_MASTER_DRIVE);
     ata_init_device(&devices[3], ATA_SECONDARY_BASE, ATA_SECONDARY_CONTROL, ATA_SLAVE_DRIVE);
-    ata_identify(&devices[0]);
-    ata_identify(&devices[1]);
-    ata_identify(&devices[2]);
-    ata_identify(&devices[3]);
+    
+    for (int i = 0; i < 4; i++){
+        ata_identify(&devices[i]);
+        if (devices[i].flags & ATA_FLAG_PRESENT){
+            block_device_t* block_device = (block_device_t*)kmalloc(sizeof(block_device_t));
+            block_device->block_count = devices[i].sector_count;
+            block_device->block_size = devices[i].sector_size;
+            block_device->read = ata_read_block;
+            block_device->write = ata_write_block;
+            block_device->data = &devices[i];
+            block_device_register(block_device);
+        }
+    }
 
     register_interrupt_handler(ATA_PRIMARY_IRQ + 32, ata_primary_irq_handler);
     register_interrupt_handler(ATA_SECONDARY_IRQ + 32, ata_secondary_irq_handler);
@@ -237,6 +258,10 @@ ata_device_t* ata_get_device(uint8_t index){
 }
 
 void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size){
+    
+    volatile uint8_t* irq_flag = NULL;
+    uint32_t sector_count = (size+511)/512;
+
     /*
     select the correct drive
     */
@@ -247,7 +272,7 @@ void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t s
     set the sector count, LBAlo, LBAmid, LBAhi registers
     */
     outb(device->base + ATA_DRIVE_HEAD_REG, 0xE0 | (device->slave<<4) | ((lba>>24)&0x0F));
-    outb(device->base + ATA_SEC_COUNT_REG, (size+511)/512);
+    outb(device->base + ATA_SEC_COUNT_REG, sector_count);
     outb(device->base + ATA_LBA_LOW_REG, ((uint8_t)lba));
     outb(device->base + ATA_LBA_MID_REG, ((uint8_t)(lba >> 8)));
     outb(device->base + ATA_LBA_HIGH_REG, ((uint8_t)(lba >> 16)));
@@ -255,7 +280,6 @@ void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t s
     /*
     set up the right irq flag
     */
-    volatile uint8_t* irq_flag = NULL;
     if (device->base == ATA_PRIMARY_BASE){
         irq_flag = &ata_primary_irq;
     }else{
@@ -277,7 +301,6 @@ void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t s
     /*
     read the data
     */
-    uint32_t sector_count = (size+511)/512;
     for (uint32_t i = 0; i < sector_count; i++){
         while (*irq_flag == 0){
             LOG_F("ATA Read LBA28: %d", lba);

--- a/drivers/blocks/ata/ata_pio.c
+++ b/drivers/blocks/ata/ata_pio.c
@@ -1,0 +1,203 @@
+#include <drivers/blocks/ata/ata.h>
+#include <kernel/mem/heap.h>
+#include <arch/x86/io/ports.h>
+#include <arch/cpu_control.h>
+#include <libc/string.h>
+#include <libc/log.h>
+
+#define ATA_PRIMARY_BASE 0x1F0
+#define ATA_SECONDARY_BASE 0x170
+
+
+#define ATA_PRIMARY_CONTROL 0x3F6
+#define ATA_SECONDARY_CONTROL 0x376
+
+#define ATA_SLAVE_DRIVE 1
+#define ATA_MASTER_DRIVE 0
+
+
+/*
+ * ATA Status Register
+ */
+#define ATA_STATUS_BSY 0x80
+#define ATA_STATUS_DRDY 0x40
+#define ATA_STATUS_DRQ 0x08
+#define ATA_STATUS_ERR 0x01
+
+/*
+ * ATA PIO Registers offsets from IO base
+ */
+#define ATA_RW_REG  0x0
+#define ATA_ERR_REG 0x1
+#define ATA_FEATURE_REG 0x1
+#define ATA_SEC_COUNT_REG 0x2
+#define ATA_LBA_LOW_REG 0x3
+#define ATA_LBA_MID_REG 0x4
+#define ATA_LBA_HIGH_REG 0x5
+#define ATA_DRIVE_HEAD_REG 0x6
+#define ATA_STATUS_REG 0x7
+#define ATA_COMMAND_REG 0x7
+
+/*
+ * ATA PIO Registers offsets from IO control base
+ */
+#define ATA_ALT_STATUS_REG 0x0
+#define ATA_CONTROL_REG 0x0
+#define ATA_DRIVE_ADDRESS_REG 0x1
+
+#define ATA_IDENRIFY_CMD 0xEC
+#define ATA_SELECT_SLAVE_DRIVE_CMD 0xB0
+#define ATA_SELECT_MASTER_DRIVE_CMD 0xA0
+
+/*
+flags
+*/
+#define ATA_FLAG_PRESENT 0x01
+#define ATA_FLAG_LBA48 0x02
+#define ATA_FLAG_LBA28 0x04
+
+
+static void ata_select_drive(ata_device_t* device);
+static uint8_t ata_read_status(ata_device_t* device);
+static void ata_identify(ata_device_t* device);
+
+static void ata_init_device(ata_device_t* device, uint16_t base, uint16_t control, uint8_t slave){
+    device->base = base;
+    device->control = control;
+    device->slave = slave;
+    device->channel = 0;
+    device->flags = 0;
+    device->sector_size = 512;
+    device->sector_count = 0;
+    device->model[0] = 0;
+}
+
+
+void ata_init(){
+    arch_disable_interrupts();
+    ata_device_t* devices = (ata_device_t*)kmalloc(sizeof(ata_device_t)*4);
+    ata_init_device(&devices[0], ATA_PRIMARY_BASE, ATA_PRIMARY_CONTROL, ATA_MASTER_DRIVE);
+    ata_init_device(&devices[1], ATA_PRIMARY_BASE, ATA_PRIMARY_CONTROL, ATA_SLAVE_DRIVE);
+    ata_init_device(&devices[2], ATA_SECONDARY_BASE, ATA_SECONDARY_CONTROL, ATA_MASTER_DRIVE);
+    ata_init_device(&devices[3], ATA_SECONDARY_BASE, ATA_SECONDARY_CONTROL, ATA_SLAVE_DRIVE);
+    ata_identify(&devices[0]);
+    ata_identify(&devices[1]);
+    ata_identify(&devices[2]);
+    ata_identify(&devices[3]);
+    arch_enable_interrupts();
+}
+
+void ata_identify(ata_device_t* device){
+    /*
+    select the correct drive
+    */
+    ata_select_drive(device);
+
+    /*
+    floating bud check
+    */
+    if (ata_read_status(device) == 0xFF){
+        LOG_ERROR("ATA Identify failed");
+        return;
+    }
+
+    /*
+    set the sector count, LBAlo, LBAmid, LBAhi registers to 0
+    */
+    outb(device->base + ATA_SEC_COUNT_REG, 0);
+    outb(device->base + ATA_LBA_LOW_REG, 0);
+    outb(device->base + ATA_LBA_MID_REG, 0);
+    outb(device->base + ATA_LBA_HIGH_REG, 0);
+
+    /*
+    send the identify command
+    */
+    outb(device->base + ATA_COMMAND_REG, ATA_IDENRIFY_CMD);
+
+    /*
+    read status register to see if the drive exists
+    */
+    if (ata_read_status(device) == 0){
+        return;
+    }
+
+    /*
+    wait for the BSY bit to clear
+    */
+    while (ata_read_status(device) & ATA_STATUS_BSY){}
+    
+    /*
+    check the LBAmid and LBAhi registers to see if they are 0
+    */
+    if (inb(device->base + ATA_LBA_MID_REG) != 0 || inb(device->base + ATA_LBA_HIGH_REG) != 0){
+        /*
+        the device is not a ATA device
+        TODO : handle this case
+        */
+        return;
+    }
+    /*
+    wait for the DRQ bit to set or error to set
+    */
+    while (!(ata_read_status(device) & ATA_STATUS_DRQ) && !(ata_read_status(device) & ATA_STATUS_ERR) ){}
+
+    /*
+    if error, return
+    */
+    if (ata_read_status(device) & ATA_STATUS_ERR){
+        return;
+    }
+
+    /*
+    read the identify data
+    */
+    uint16_t* buffer = (uint16_t*)kmalloc(sizeof(uint16_t)*256);
+    for (int i = 0; i < 256; i++){
+        buffer[i] = inw(device->base + ATA_RW_REG);
+    }
+    /*
+    parse the identify data
+    extract the model string
+    extract the sector count
+    extract the LBA48 support
+    */
+    for (int i = 0; i < 40; i+=2){
+        device->model[i] = (buffer[27+(i/2)]>>8) & 0xFF;
+        device->model[i+1] = buffer[27+(i/2)] & 0xFF;
+    }
+    device->model[41] = '\0';
+
+    if (buffer[83] & (1<<10)){
+        device->flags |= ATA_FLAG_LBA48;
+        device->sector_count = 
+            (uint64_t)buffer[100] |
+            ((uint64_t)buffer[101]<<16) |
+            ((uint64_t)buffer[102]<<32) |
+            ((uint64_t)buffer[103]<<48);
+    } else {
+        device->flags |= ATA_FLAG_LBA28;
+        device->sector_count = 
+            (uint64_t)buffer[60] |
+            ((uint64_t)buffer[61]<<16);
+    }
+    device->flags |= ATA_FLAG_PRESENT;
+    LOG_F("ATA Drive Identified: %s, Sectors: %d (Size: %d MB)", 
+          device->model, 
+          device->sector_count, 
+          (device->sector_count * 512) / 1024);
+    kfree(buffer);
+}
+
+void ata_select_drive(ata_device_t* device){
+    if (device->slave){
+        outb(device->base + ATA_DRIVE_HEAD_REG, ATA_SELECT_SLAVE_DRIVE_CMD);
+    }else{
+        outb(device->base + ATA_DRIVE_HEAD_REG, ATA_SELECT_MASTER_DRIVE_CMD);
+    }
+}
+
+uint8_t ata_read_status(ata_device_t* device){
+    return inb(device->base + ATA_STATUS_REG);
+}
+
+

--- a/drivers/blocks/ata/ata_pio.c
+++ b/drivers/blocks/ata/ata_pio.c
@@ -2,6 +2,8 @@
 #include <kernel/mem/heap.h>
 #include <arch/x86/io/ports.h>
 #include <arch/cpu_control.h>
+#include <arch/interrupt_controller.h>
+#include <cpu/int.h>
 #include <libc/string.h>
 #include <libc/log.h>
 
@@ -45,9 +47,15 @@
 #define ATA_CONTROL_REG 0x0
 #define ATA_DRIVE_ADDRESS_REG 0x1
 
+/*
+ * ATA Commands
+ */
 #define ATA_IDENRIFY_CMD 0xEC
 #define ATA_SELECT_SLAVE_DRIVE_CMD 0xB0
 #define ATA_SELECT_MASTER_DRIVE_CMD 0xA0
+#define ATA_READ_CMD 0x20
+#define ATA_WRITE_CMD 0x30
+#define ATA_SELECT_LBA48_CMD 0x24
 
 /*
 flags
@@ -56,10 +64,28 @@ flags
 #define ATA_FLAG_LBA48 0x02
 #define ATA_FLAG_LBA28 0x04
 
+/*
+ * ATA Interrupts
+ */
+#define ATA_PRIMARY_IRQ 14
+#define ATA_SECONDARY_IRQ 15
 
+
+/*
+* ATA Functions
+*/
+ata_device_t* ata_get_device(uint8_t index);
+void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
 static void ata_select_drive(ata_device_t* device);
 static uint8_t ata_read_status(ata_device_t* device);
 static void ata_identify(ata_device_t* device);
+static void ata_read_lba48(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
+void ata_primary_irq_handler(registers_t regs);
+void ata_secondary_irq_handler(registers_t regs);
+
+static ata_device_t* devices;
+static uint8_t ata_primary_irq;
+static uint8_t ata_secondary_irq;
 
 static void ata_init_device(ata_device_t* device, uint16_t base, uint16_t control, uint8_t slave){
     device->base = base;
@@ -75,7 +101,7 @@ static void ata_init_device(ata_device_t* device, uint16_t base, uint16_t contro
 
 void ata_init(){
     arch_disable_interrupts();
-    ata_device_t* devices = (ata_device_t*)kmalloc(sizeof(ata_device_t)*4);
+    devices = (ata_device_t*)kmalloc(sizeof(ata_device_t)*4);
     ata_init_device(&devices[0], ATA_PRIMARY_BASE, ATA_PRIMARY_CONTROL, ATA_MASTER_DRIVE);
     ata_init_device(&devices[1], ATA_PRIMARY_BASE, ATA_PRIMARY_CONTROL, ATA_SLAVE_DRIVE);
     ata_init_device(&devices[2], ATA_SECONDARY_BASE, ATA_SECONDARY_CONTROL, ATA_MASTER_DRIVE);
@@ -84,6 +110,11 @@ void ata_init(){
     ata_identify(&devices[1]);
     ata_identify(&devices[2]);
     ata_identify(&devices[3]);
+
+    register_interrupt_handler(ATA_PRIMARY_IRQ + 32, ata_primary_irq_handler);
+    register_interrupt_handler(ATA_SECONDARY_IRQ + 32, ata_secondary_irq_handler);
+    ata_primary_irq = 0;
+    ata_secondary_irq = 0;
     arch_enable_interrupts();
 }
 
@@ -184,7 +215,7 @@ void ata_identify(ata_device_t* device){
     LOG_F("ATA Drive Identified: %s, Sectors: %d (Size: %d MB)", 
           device->model, 
           device->sector_count, 
-          (device->sector_count * 512) / 1024);
+          (uint32_t)(device->sector_count * 512) / 1024 / 1024);
     kfree(buffer);
 }
 
@@ -196,8 +227,143 @@ void ata_select_drive(ata_device_t* device){
     }
 }
 
+
 uint8_t ata_read_status(ata_device_t* device){
     return inb(device->base + ATA_STATUS_REG);
 }
 
+ata_device_t* ata_get_device(uint8_t index){
+    return &devices[index];
+}
 
+void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size){
+    /*
+    select the correct drive
+    */
+    ata_select_drive(device);
+    while (ata_read_status(device) & ATA_STATUS_BSY){}
+    LOG_F("ATA Read LBA28: %d", lba);
+    /*
+    set the sector count, LBAlo, LBAmid, LBAhi registers
+    */
+    outb(device->base + ATA_DRIVE_HEAD_REG, 0xE0 | (device->slave<<4) | ((lba>>24)&0x0F));
+    outb(device->base + ATA_SEC_COUNT_REG, (size+511)/512);
+    outb(device->base + ATA_LBA_LOW_REG, ((uint8_t)lba));
+    outb(device->base + ATA_LBA_MID_REG, ((uint8_t)(lba >> 8)));
+    outb(device->base + ATA_LBA_HIGH_REG, ((uint8_t)(lba >> 16)));
+
+    /*
+    set up the right irq flag
+    */
+    volatile uint8_t* irq_flag = NULL;
+    if (device->base == ATA_PRIMARY_BASE){
+        irq_flag = &ata_primary_irq;
+    }else{
+        irq_flag = &ata_secondary_irq;
+    }
+    *irq_flag = 0;
+
+    LOG_F("ATA Read LBA28: %d", lba);
+    /*
+    send the read command
+    */
+    outb(device->base + ATA_COMMAND_REG, ATA_READ_CMD);
+
+    /*
+    wait for the BSY bit to clear
+    */
+    while (ata_read_status(device) & ATA_STATUS_BSY){}
+    LOG_F("ATA Read LBA28: %d", lba);
+    /*
+    read the data
+    */
+    uint32_t sector_count = (size+511)/512;
+    for (uint32_t i = 0; i < sector_count; i++){
+        while (*irq_flag == 0){
+            LOG_F("ATA Read LBA28: %d", lba);
+            arch_halt();
+        }
+        *irq_flag = 0;
+        for (uint32_t j = 0; j < 256; j++){
+            ((uint16_t*)buffer)[i*256 + j] = inw(device->base + ATA_RW_REG);
+        }
+    }
+}
+void ata_write_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size){
+    uint32_t sector_count = (size+511)/512;
+    uint16_t* sector_buffer = (uint16_t*)buffer;
+    /*
+    select the correct drive
+    */
+    ata_select_drive(device);
+    while (ata_read_status(device) & ATA_STATUS_BSY){}
+    /*
+    set the sector count, LBAlo, LBAmid, LBAhi registers
+    */
+    outb(device->base + ATA_DRIVE_HEAD_REG, 0xE0 | (device->slave<<4) | ((lba>>24)&0x0F));
+    outb(device->base + ATA_SEC_COUNT_REG, sector_count);
+    outb(device->base + ATA_LBA_LOW_REG, ((uint8_t)lba));
+    outb(device->base + ATA_LBA_MID_REG, ((uint8_t)(lba >> 8)));
+    outb(device->base + ATA_LBA_HIGH_REG, ((uint8_t)(lba >> 16)));
+
+    /*
+    set up the right irq flag
+    */
+    volatile uint8_t* irq_flag = NULL;
+    if (device->base == ATA_PRIMARY_BASE){
+        irq_flag = &ata_primary_irq;
+    }else{
+        irq_flag = &ata_secondary_irq;
+    }
+    *irq_flag = 0;
+
+    /*
+    send the Write command
+    */
+    outb(device->base + ATA_COMMAND_REG, ATA_WRITE_CMD);
+    /*
+    write the data
+    */
+    for (uint32_t i = 0; i < sector_count; i++){
+        /*
+        wait for the DRQ bit to set
+        */
+        while (1){
+            uint8_t status = ata_read_status(device);
+            if (status & ATA_STATUS_ERR) return;
+            if (!(status & ATA_STATUS_BSY) && (status & ATA_STATUS_DRQ)){
+                break;
+            }
+        }
+        
+        for (uint32_t j = 0; j < 256; j++){
+            outw(device->base + ATA_RW_REG, sector_buffer[i*256+j]);
+        }
+        while (*irq_flag == 0){
+            arch_halt();
+        }
+        *irq_flag = 0;
+    }
+    /*
+    flush cache
+    */
+    outb(device->base + ATA_COMMAND_REG, 0xE7);
+    while (*irq_flag == 0){
+        arch_halt();
+    }
+    *irq_flag = 0;
+}
+
+void ata_primary_irq_handler(registers_t regs){
+    LOG("ATA Primary IRQ");
+    inb(ATA_PRIMARY_BASE + ATA_STATUS_REG);
+    ata_primary_irq = 1;
+    arch_irq_send_eoi(ATA_PRIMARY_IRQ + 32);
+}
+
+void ata_secondary_irq_handler(registers_t regs){
+    LOG("ATA Secondary IRQ");
+    inb(ATA_SECONDARY_BASE + ATA_STATUS_REG);
+    ata_secondary_irq = 1;
+    arch_irq_send_eoi(ATA_SECONDARY_IRQ + 32);
+}

--- a/drivers/blocks/block_device.c
+++ b/drivers/blocks/block_device.c
@@ -1,0 +1,28 @@
+#include <drivers/blocks/block_device.h>
+#include <libc/log.h>
+
+#define MAX_BLOCK_DEVICES 16
+
+static block_device_t* devices[MAX_BLOCK_DEVICES];
+static uint8_t device_count = 0;
+
+void block_device_register(block_device_t* device){
+    if (device_count >= MAX_BLOCK_DEVICES){
+        LOG_ERROR("Block device register failed: too many devices");
+        return;
+    }
+    devices[device_count] = device;
+    device_count++;
+}
+
+block_device_t* block_device_get(uint8_t index){
+    if (index >= device_count){
+        LOG_ERROR("Block device get failed: invalid index");
+        return NULL;
+    }
+    return devices[index];
+}
+
+uint8_t block_device_count(){
+    return device_count;
+}

--- a/includes/drivers/blocks/ata/ata.h
+++ b/includes/drivers/blocks/ata/ata.h
@@ -1,0 +1,26 @@
+#ifndef ATA_H
+#define ATA_H
+
+#include <unit_types.h>
+
+typedef struct ata_device {
+    uint16_t base;
+    uint16_t control;
+    uint8_t  slave;
+    uint8_t  channel;
+
+    uint8_t  flags;
+
+    uint32_t sector_size;
+    uint64_t sector_count;
+
+    char model[41];
+} ata_device_t;
+
+
+void ata_read(uint64_t lba, void* buffer, uint32_t size);
+void ata_write(uint64_t lba, void* buffer, uint32_t size);
+
+void ata_init();
+
+#endif

--- a/includes/drivers/blocks/ata/ata.h
+++ b/includes/drivers/blocks/ata/ata.h
@@ -18,8 +18,9 @@ typedef struct ata_device {
 } ata_device_t;
 
 
-void ata_read(uint64_t lba, void* buffer, uint32_t size);
-void ata_write(uint64_t lba, void* buffer, uint32_t size);
+void ata_read_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
+void ata_write_lba28(ata_device_t* device, uint64_t lba, void* buffer, uint32_t size);
+ata_device_t* ata_get_device(uint8_t index);
 
 void ata_init();
 

--- a/includes/drivers/blocks/block_device.h
+++ b/includes/drivers/blocks/block_device.h
@@ -1,0 +1,18 @@
+#ifndef BLOCK_DEVICE_H
+#define BLOCK_DEVICE_H
+
+#include <unit_types.h>
+
+typedef struct block_device_t {
+    uint64_t block_count;
+    uint32_t block_size;
+    void (*read)(block_device_t* device, uint64_t block, void* buffer, uint32_t size);
+    void (*write)(block_device_t* device, uint64_t block, void* buffer, uint32_t size);
+    void* data;
+} block_device_t;
+
+void block_device_register(block_device_t* device);
+block_device_t* block_device_get(uint8_t index);
+uint8_t block_device_count();
+
+#endif

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -1,6 +1,7 @@
 #include <drivers/screen.h>
 #include <boot/multiboot_helpers.h>
 #include <libc/string.h>
+#include <libc/mem.h>
 #include <cpu/int.h>
 #include <drivers/keyboard.h>
 #include <drivers/display/console.h>
@@ -62,31 +63,6 @@ extern "C" void kernel_main(multiboot_info_t* mb_info){
                 printk("  test  - Run libc tests\n");
                 printk("  time  - display the time\n");
                 printk("  heap  - display the heap\n");
-                printk("  read  - test ATA read (Sector 0)\n");
-                printk("  write - test ATA write (Sector 0)\n");
-            } else if (strcmp(buffer, (char*)"read") == 0) {
-                 ata_device_t* dev = ata_get_device(0);
-                 if (dev->flags & 0x01) {
-                     uint16_t* sector = (uint16_t*)kmalloc(512);
-                     printk("ATA Sector 0 Data: ");
-                     ata_read_lba28(dev, 0, sector, 512);
-                     printk("Sector 0 Data: ");
-
-                     for(int i=0; i<100; i++) printk("%x ", ((uint32_t*)sector)[i]);
-                     printk("\n");
-                     kfree(sector);
-                 } else {
-                     printk("Primary Master not found.\n");
-                 }
-            } else if (strcmp(buffer, (char*)"write") == 0) {
-                 ata_device_t* dev = ata_get_device(0);
-                 if (dev->flags & 0x01) {
-                     uint16_t* sector = (uint16_t*)"ATA Sector 0 Data: deedede";
-                     printk("ATA Sector 0 Data: ");
-                     ata_write_lba28(dev, 0, sector, 26);
-                 } else {
-                     printk("Primary Master not found.\n");
-                 }
             } else if (strcmp(buffer, (char*)"clear") == 0) {
                 clean_screen();
             } else if (strcmp(buffer, (char*)"mem") == 0) {

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -5,6 +5,7 @@
 #include <drivers/keyboard.h>
 #include <drivers/display/console.h>
 #include <drivers/display/vbe.h>
+#include <drivers/blocks/ata/ata.h>
 #include <kernel/mem/heap.h> 
 #include <kernel/mem/pmm.h>
 #include <kernel/mem/vmm.h>
@@ -43,7 +44,8 @@ extern "C" void kernel_main(multiboot_info_t* mb_info){
     init_vmm(multiboot_info);
     init_heap();
     console_init(multiboot_info);
-    init_clock();    
+    init_clock();
+    ata_init();
     // printk("Welcome to OS from Scratch!\n");
     // printk("Type 'help' for commands.\n");
     // printk("os > ");

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -62,6 +62,31 @@ extern "C" void kernel_main(multiboot_info_t* mb_info){
                 printk("  test  - Run libc tests\n");
                 printk("  time  - display the time\n");
                 printk("  heap  - display the heap\n");
+                printk("  read  - test ATA read (Sector 0)\n");
+                printk("  write - test ATA write (Sector 0)\n");
+            } else if (strcmp(buffer, (char*)"read") == 0) {
+                 ata_device_t* dev = ata_get_device(0);
+                 if (dev->flags & 0x01) {
+                     uint16_t* sector = (uint16_t*)kmalloc(512);
+                     printk("ATA Sector 0 Data: ");
+                     ata_read_lba28(dev, 0, sector, 512);
+                     printk("Sector 0 Data: ");
+
+                     for(int i=0; i<100; i++) printk("%x ", ((uint32_t*)sector)[i]);
+                     printk("\n");
+                     kfree(sector);
+                 } else {
+                     printk("Primary Master not found.\n");
+                 }
+            } else if (strcmp(buffer, (char*)"write") == 0) {
+                 ata_device_t* dev = ata_get_device(0);
+                 if (dev->flags & 0x01) {
+                     uint16_t* sector = (uint16_t*)"ATA Sector 0 Data: deedede";
+                     printk("ATA Sector 0 Data: ");
+                     ata_write_lba28(dev, 0, sector, 26);
+                 } else {
+                     printk("Primary Master not found.\n");
+                 }
             } else if (strcmp(buffer, (char*)"clear") == 0) {
                 clean_screen();
             } else if (strcmp(buffer, (char*)"mem") == 0) {


### PR DESCRIPTION
This pull request adds foundational support for ATA PIO-based block device drivers and a generic block device interface to the kernel. It introduces new source files for ATA and block device management, integrates ATA device initialization into the kernel boot sequence, and updates the build system to include new C source files in nested directories.

**ATA Block Device Driver and Block Device Abstraction:**

* Introduced a new ATA PIO driver (`ata_pio.c`) for detecting, identifying, reading, and writing ATA drives, including IRQ handling and support for both LBA28 and LBA48 addressing. The driver registers detected drives as block devices.
* Added a generic block device interface (`block_device.c` and `block_device.h`) to abstract block device registration, access, and counting, supporting up to 16 devices. [[1]](diffhunk://#diff-97af928eba7b998ebd35d22dfeac3968c33281ff49713edf7be7be53eb3adcfbR1-R28) [[2]](diffhunk://#diff-573e19fabf9ec9da6a05c98710e49ee8f8d25ddc063c9bf015a851d10dc38016R1-R18)
* Defined the `ata_device_t` structure and relevant ATA driver APIs in a new header (`ata.h`).

**Kernel Integration:**

* Modified `kernel.cpp` to include the new ATA driver and initialize ATA devices during kernel startup, ensuring block devices are available early in the boot process. [[1]](diffhunk://#diff-f0a47a53c63f79dc024c8ce88c513af0384db4eda931f57e2d1c7189f8aed619R4-R9) [[2]](diffhunk://#diff-f0a47a53c63f79dc024c8ce88c513af0384db4eda931f57e2d1c7189f8aed619R49)

**Build System Update:**

* Updated the `Makefile` to include C source files from nested directories under `drivers/`, ensuring the new drivers are compiled.